### PR TITLE
[bugfix] Replace launchWhenCreated with repeatOnLifecycle

### DIFF
--- a/docs/processing.md
+++ b/docs/processing.md
@@ -36,8 +36,10 @@ override fun onCreate(savedInstanceState: Bundle?) {
      * This is an example to show it being called in onCreate(). but can
      * be called later in lifecycle as per business use-case requirement
      */
-    lifecycleScope.launchWhenCreated {
-        activateProcessingSession()
+    lifecycleScope.launch {
+        repeatOnLifecycle(Lifecycle.State.CREATED) {
+            activateProcessingSession()
+        }
     }
 }
 

--- a/standard-integration/app/src/main/java/io/mimi/example/android/MainActivity.kt
+++ b/standard-integration/app/src/main/java/io/mimi/example/android/MainActivity.kt
@@ -18,13 +18,16 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import io.mimi.example.android.applicators.IntensityApplicator
 import io.mimi.example.android.applicators.IsEnabledApplicator
 import io.mimi.example.android.applicators.PresetApplicator
 import io.mimi.sdk.core.MimiCore
 import io.mimi.sdk.core.controller.processing.*
 import io.mimi.sdk.core.model.personalization.Personalization
+import kotlinx.coroutines.launch
 
 class MainActivity : AppCompatActivity() {
 
@@ -44,8 +47,10 @@ class MainActivity : AppCompatActivity() {
          * which have been held at a different lifecycle scope, then they
          * become invalid.
          */
-        lifecycleScope.launchWhenCreated {
-            activateProcessingSession()
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.CREATED) {
+                activateProcessingSession()
+            }
         }
     }
 


### PR DESCRIPTION
## Issue
[`launchWhenCreated`](https://developer.android.com/reference/kotlin/androidx/lifecycle/LifecycleCoroutineScope#launchWhenCreated(kotlin.coroutines.SuspendFunction1)) is not recommended anymore.

![Screenshot 2023-03-02 at 08 47 41](https://user-images.githubusercontent.com/2096087/222365356-1cc7301a-ae35-419f-8257-f6a3ab956604.png)


## Solution:

Replaced with `repeatOnLifecycle` implementation.

Also updated the docs.