### PR TITLE
[MSDK-6513] Bump to MSDK 8.1.1

### DIFF
--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -51,4 +51,16 @@ dependencies {
 
     // Mimi SDK
     implementation "io.mimi:sdk:$rootProject.ext.msdkVer"
+
+    // If the app and dependencies keep using Kotlin 1.7.x, then follow the instructions here:
+    // https://youtrack.jetbrains.com/issue/KT-54136/Duplicated-classes-cause-build-failure-if-a-dependency-to-kotlin-stdlib-specified-in-an-android-project
+    // to avoid duplicated classes error.
+    constraints {
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
+            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+        }
+        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
+            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+        }
+    }
 }

--- a/standard-integration/build.gradle
+++ b/standard-integration/build.gradle
@@ -50,7 +50,7 @@ task clean(type: Delete) {
 ext {
     mimiClientID = getBuildProperty("mimiClientID", "CLIENT_ID")
     mimiClientSecret = getBuildProperty("mimiClientSecret", "CLIENT_SECRET")
-    msdkVer = "8.0.0"
+    msdkVer = "8.1.1"
 }
 
 //region Get ENV vars


### PR DESCRIPTION
Upgrades to MSDK 8.1.1

This needs a workaround due to this error https://youtrack.jetbrains.com/issue/KT-54136/Duplicated-classes-cause-build-failure-if-a-dependency-to-kotlin-stdlib-specified-in-an-android-project

Note: bumping `kotlin_version = "1.8.22"` also resolves the issue, but I think this technique can be a demonstration for those partners still using Kotlin 1.7.x.