### PR TITLE
Bump to AGP 8.1.0, Kotlin 1.8.22 and add realistic release build type with signing and minification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
+## 1.2.0
 
+- Bump to AGP 8.1.0
+- Bump to Kotlin 1.8.22
+- Add dummy signing
+- Add R8 minimization configuration
 
 ## 1.1.0
 

--- a/standard-integration/.gitignore
+++ b/standard-integration/.gitignore
@@ -1,0 +1,1 @@
+/keystore

--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "io.mimi.example.integrationexamplemsdk_android"
         minSdk 21
         targetSdk 34
-        versionCode 2
-        versionName "1.1.0"
+        versionCode 3
+        versionName "1.2.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
@@ -69,15 +69,4 @@ dependencies {
     // Mimi SDK
     implementation "io.mimi:sdk:$rootProject.ext.msdkVer"
 
-//    // If the app and dependencies keep using Kotlin 1.7.x, then follow the instructions here:
-//    // https://youtrack.jetbrains.com/issue/KT-54136/Duplicated-classes-cause-build-failure-if-a-dependency-to-kotlin-stdlib-specified-in-an-android-project
-//    // to avoid duplicated classes error.
-//    constraints {
-//        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
-//            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
-//        }
-//        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
-//            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
-//        }
-//    }
 }

--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -6,6 +6,12 @@ plugins {
 android {
     compileSdk 34
 
+    namespace "io.mimi.example.android"
+
+    buildFeatures {
+        buildConfig = true
+    }
+
     defaultConfig {
         applicationId "io.mimi.example.integrationexamplemsdk_android"
         minSdk 21

--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -22,15 +22,27 @@ android {
         buildConfigField("String", "MY_CLIENT_SECRET", rootProject.ext.mimiClientSecret)
     }
 
+    signingConfigs {
+        dummy {
+            storeFile file("${rootProject.projectDir}/keystore/dummy.keystore")
+            storePassword getBuildProperty("dummyKeystoreStorePassword", "DUMMY_KEYSTORE_STORE_PASSWORD")
+            keyAlias getBuildProperty("dummyKeystoreKeyAlias", "DUMMY_KEYSTORE_KEY_ALIAS")
+            keyPassword getBuildProperty("dummyKeystoreKeyPassword", "DUMMY_KEYSTORE_KEY_PASSWORD")
+            v1SigningEnabled true
+            v2SigningEnabled true
+        }
+    }
+
     buildTypes {
         release {
-            minifyEnabled false
+            minifyEnabled true
             proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
+            signingConfig signingConfigs.dummy
         }
     }
 
     buildFeatures {
-        buildConfig = true
+        buildConfig true
         viewBinding true
     }
 }

--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -3,11 +3,14 @@ plugins {
     id 'kotlin-android'
 }
 
-android {
-    compileSdk 34
+kotlin {
+    jvmToolchain(8)
+}
 
+android {
     namespace "io.mimi.example.android"
 
+    compileSdk 34
     defaultConfig {
         applicationId "io.mimi.example.integrationexamplemsdk_android"
         minSdk 21
@@ -16,7 +19,6 @@ android {
         versionName "1.1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
 
         buildConfigField("String", "MY_CLIENT_ID", rootProject.ext.mimiClientID)
         buildConfigField("String", "MY_CLIENT_SECRET", rootProject.ext.mimiClientSecret)
@@ -67,15 +69,15 @@ dependencies {
     // Mimi SDK
     implementation "io.mimi:sdk:$rootProject.ext.msdkVer"
 
-    // If the app and dependencies keep using Kotlin 1.7.x, then follow the instructions here:
-    // https://youtrack.jetbrains.com/issue/KT-54136/Duplicated-classes-cause-build-failure-if-a-dependency-to-kotlin-stdlib-specified-in-an-android-project
-    // to avoid duplicated classes error.
-    constraints {
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
-            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
-        }
-        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
-            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
-        }
-    }
+//    // If the app and dependencies keep using Kotlin 1.7.x, then follow the instructions here:
+//    // https://youtrack.jetbrains.com/issue/KT-54136/Duplicated-classes-cause-build-failure-if-a-dependency-to-kotlin-stdlib-specified-in-an-android-project
+//    // to avoid duplicated classes error.
+//    constraints {
+//        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.8.0") {
+//            because("kotlin-stdlib-jdk7 is now a part of kotlin-stdlib")
+//        }
+//        implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.8.0") {
+//            because("kotlin-stdlib-jdk8 is now a part of kotlin-stdlib")
+//        }
+//    }
 }

--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -8,10 +8,6 @@ android {
 
     namespace "io.mimi.example.android"
 
-    buildFeatures {
-        buildConfig = true
-    }
-
     defaultConfig {
         applicationId "io.mimi.example.integrationexamplemsdk_android"
         minSdk 21
@@ -34,6 +30,7 @@ android {
     }
 
     buildFeatures {
+        buildConfig = true
         viewBinding true
     }
 }

--- a/standard-integration/app/proguard-rules.pro
+++ b/standard-integration/app/proguard-rules.pro
@@ -42,14 +42,9 @@
  # is used.
  -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
-# Silence missing classes warnings
--dontwarn org.bouncycastle.jsse.BCSSLParameters
--dontwarn org.bouncycastle.jsse.BCSSLSocket
--dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
--dontwarn org.conscrypt.Conscrypt$Version
--dontwarn org.conscrypt.Conscrypt
--dontwarn org.conscrypt.ConscryptHostnameVerifier
--dontwarn org.openjsse.javax.net.ssl.SSLParameters
--dontwarn org.openjsse.javax.net.ssl.SSLSocket
--dontwarn org.openjsse.net.ssl.OpenJSSE
+# Silence missing classes errors: would be fixed with OkHttp 4.11.0.
+# See https://github.com/square/okhttp/issues/6258
+-dontwarn org.conscrypt.**
+-dontwarn org.bouncycastle.**
+-dontwarn org.openjsse.**
 

--- a/standard-integration/app/proguard-rules.pro
+++ b/standard-integration/app/proguard-rules.pro
@@ -30,6 +30,18 @@
 ################ Kotlin specific rules ################
 -keep class kotlin.Metadata { *; }
 
+################ Updated Retrofit rules for R8 full mode ################
+# See - https://github.com/square/retrofit/issues/3751
+
+# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
+ -keep,allowobfuscation,allowshrinking interface retrofit2.Call
+ -keep,allowobfuscation,allowshrinking class retrofit2.Response
+
+ # With R8 full mode generic signatures are stripped for classes that are not
+ # kept. Suspend functions are wrapped in continuations where the type argument
+ # is used.
+ -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
+
 # Silence missing classes warnings
 -dontwarn org.bouncycastle.jsse.BCSSLParameters
 -dontwarn org.bouncycastle.jsse.BCSSLSocket

--- a/standard-integration/app/proguard-rules.pro
+++ b/standard-integration/app/proguard-rules.pro
@@ -19,3 +19,25 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+############### Mimi SDK specific rules ################
+-keep class io.mimi.sdk.core.model.** { *; }
+-keep class io.mimi.sdk.core.api.** { *; }
+-keep class io.mimi.hte.HTENativeWrapper { *; }
+-keep public enum io.mimi.hte.** { *; }
+-keep class * extends io.mimi.sdk.ux.flow.view.Section { <init>(*); } # Keeping all classes extending Section class due to reflection issues with Proguard/R8
+
+################ Kotlin specific rules ################
+-keep class kotlin.Metadata { *; }
+
+# Silence missing classes warnings
+-dontwarn org.bouncycastle.jsse.BCSSLParameters
+-dontwarn org.bouncycastle.jsse.BCSSLSocket
+-dontwarn org.bouncycastle.jsse.provider.BouncyCastleJsseProvider
+-dontwarn org.conscrypt.Conscrypt$Version
+-dontwarn org.conscrypt.Conscrypt
+-dontwarn org.conscrypt.ConscryptHostnameVerifier
+-dontwarn org.openjsse.javax.net.ssl.SSLParameters
+-dontwarn org.openjsse.javax.net.ssl.SSLSocket
+-dontwarn org.openjsse.net.ssl.OpenJSSE
+

--- a/standard-integration/app/src/main/AndroidManifest.xml
+++ b/standard-integration/app/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="io.mimi.example.android">
+    xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
 

--- a/standard-integration/build.gradle
+++ b/standard-integration/build.gradle
@@ -2,7 +2,7 @@
 buildscript {
     ext {
         kotlin_version = "1.7.20"
-        agp_version = "7.4.1"
+        agp_version = "8.1.0"
     }
 
     repositories {

--- a/standard-integration/build.gradle
+++ b/standard-integration/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 buildscript {
     ext {
-        kotlin_version = "1.7.20"
+        kotlin_version = "1.8.22"
         agp_version = "8.1.0"
     }
 

--- a/standard-integration/gradle/wrapper/gradle-wrapper.properties
+++ b/standard-integration/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
In order to more realistically behave like a partner app, I have added app minification to the release variant, along with a signing configuration.

As the behavior of R8 is different in AGP 8.x (Full Mode is the default), I've also upgrade the AGP to 8.1.x to verify the behavior with the latest tooling.