### PR TITLE
[MSDK-6689] Bump MSDK version to 9.0.1, bump app version

### DIFF
--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "io.mimi.example.integrationexamplemsdk_android"
         minSdk 21
         targetSdk 34
-        versionCode 3
-        versionName "1.2.0"
+        versionCode 4
+        versionName "1.2.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/standard-integration/build.gradle
+++ b/standard-integration/build.gradle
@@ -43,14 +43,14 @@ allprojects {
     }
 }
 
-task clean(type: Delete) {
+tasks.register('clean', Delete) {
     delete rootProject.buildDir
 }
 
 ext {
     mimiClientID = getBuildProperty("mimiClientID", "CLIENT_ID")
     mimiClientSecret = getBuildProperty("mimiClientSecret", "CLIENT_SECRET")
-    msdkVer = "9.0.0"
+    msdkVer = "9.0.1"
 }
 
 //region Get ENV vars


### PR DESCRIPTION
Updates the MSDK dependency to 9.0.1

No app migration is required.