### PR TITLE
[MSDK-6711] Upgrade MSDK to 9.1.0

### DIFF
--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -15,8 +15,8 @@ android {
         applicationId "io.mimi.example.integrationexamplemsdk_android"
         minSdk 21
         targetSdk 34
-        versionCode 4
-        versionName "1.2.1"
+        versionCode 5
+        versionName "1.3.1"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 

--- a/standard-integration/app/proguard-rules.pro
+++ b/standard-integration/app/proguard-rules.pro
@@ -20,27 +20,8 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-############### Mimi SDK specific rules ################
--keep class io.mimi.sdk.core.model.** { *; }
--keep class io.mimi.sdk.core.api.** { *; }
--keep class io.mimi.hte.HTENativeWrapper { *; }
--keep public enum io.mimi.hte.** { *; }
--keep class * extends io.mimi.sdk.ux.flow.view.Section { <init>(*); } # Keeping all classes extending Section class due to reflection issues with Proguard/R8
-
-################ Kotlin specific rules ################
+################# Kotlin specific rules ################
 -keep class kotlin.Metadata { *; }
-
-################ Updated Retrofit rules for R8 full mode ################
-# See - https://github.com/square/retrofit/issues/3751
-
-# Keep generic signature of Call, Response (R8 full mode strips signatures from non-kept items).
- -keep,allowobfuscation,allowshrinking interface retrofit2.Call
- -keep,allowobfuscation,allowshrinking class retrofit2.Response
-
- # With R8 full mode generic signatures are stripped for classes that are not
- # kept. Suspend functions are wrapped in continuations where the type argument
- # is used.
- -keep,allowobfuscation,allowshrinking class kotlin.coroutines.Continuation
 
 # Silence missing classes errors: would be fixed with OkHttp 4.11.0.
 # See https://github.com/square/okhttp/issues/6258

--- a/standard-integration/build.gradle
+++ b/standard-integration/build.gradle
@@ -50,7 +50,7 @@ tasks.register('clean', Delete) {
 ext {
     mimiClientID = getBuildProperty("mimiClientID", "CLIENT_ID")
     mimiClientSecret = getBuildProperty("mimiClientSecret", "CLIENT_SECRET")
-    msdkVer = "9.0.1"
+    msdkVer = "9.1.0"
 }
 
 //region Get ENV vars


### PR DESCRIPTION
- Upgrades the MSDK to 9.1.0 (which includes `consumer-proguard-rules.pro`)
- Applies the correct `proguard-rules.pro`.

We should follow up if the following rules should be included in the MSDK `consumer-proguard-rules.pro`, as this app crashes without it.

```
################# Kotlin specific rules ################
-keep class kotlin.Metadata { *; }
```

Crash was:

```
nb.f: Property 'tokens' (JVM signature: getTokens()Lio/mimi/sdk/core/securestore/Tokens;) not resolved in class io.mimi.sdk.core.securestore.PersistentAuthStore
             at hc.z0.invoke(SourceFile:402)
             at hc.i1.n2(SourceFile:29)
             at hc.a1.z(SourceFile:1)
             at hc.a1.v(SourceFile:1)
```