### PR TITLE
Update mSDK to 10.1.0, add submitAudiogram example

### DIFF
--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -3,10 +3,6 @@ plugins {
     id 'kotlin-android'
 }
 
-kotlin {
-    jvmToolchain(8)
-}
-
 android {
     namespace "io.mimi.example.android"
 
@@ -46,6 +42,14 @@ android {
     buildFeatures {
         buildConfig true
         viewBinding true
+    }
+
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+    kotlinOptions {
+        jvmTarget = JavaVersion.VERSION_1_8
     }
 }
 

--- a/standard-integration/app/src/main/res/layout/activity_main.xml
+++ b/standard-integration/app/src/main/res/layout/activity_main.xml
@@ -4,6 +4,7 @@
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:gravity="center"
+    android:orientation="vertical"
     tools:context=".MainActivity">
 
     <androidx.fragment.app.FragmentContainerView
@@ -11,5 +12,13 @@
         android:name="io.mimi.sdk.profile.MimiProfileLauncher"
         android:layout_width="320dp"
         android:layout_height="200dp" />
+
+    <Button
+        android:id="@+id/sendCustomAudiogramBtn"
+        android:layout_width="304dp"
+        android:layout_height="wrap_content"
+        style="@style/Widget.Mimi.Button"
+        android:layout_marginTop="8dp"
+        android:text="Send custom audiogram" />
 
 </LinearLayout>

--- a/standard-integration/build.gradle
+++ b/standard-integration/build.gradle
@@ -50,7 +50,7 @@ tasks.register('clean', Delete) {
 ext {
     mimiClientID = getBuildProperty("mimiClientID", "CLIENT_ID")
     mimiClientSecret = getBuildProperty("mimiClientSecret", "CLIENT_SECRET")
-    msdkVer = "10.0.0"
+    msdkVer = "10.1.0"
 }
 
 //region Get ENV vars


### PR DESCRIPTION
## Upgrades to 10.1.0

Includes:
- Added `TestsController.submitAudiogram()` for Audiogram submission.
    - Added the following classes in support of this:
        - `io.mimi.sdk.core.model.tests.MimiTestAudiogram`
        - `io.mimi.sdk.core.model.tests.MimiTestAudiogram.DataPoint`
        - `io.mimi.sdk.core.model.tests.TestAudiogramMetadata`
        - `io.mimi.sdk.core.model.tests.MimiTestAudiogramResponse`

## Added source code example to submit a custom audiogram

https://github.com/MimiHearingTechnologies/IntegrationExampleMSDK-Android/assets/24294964/c83fbb07-5bad-42e9-b9a3-816d3b25a50f

