### PR TITLE
[MSDK-7121] Remove MSDK Mimi launcher from example

### DIFF
--- a/docs/profile.md
+++ b/docs/profile.md
@@ -1,34 +1,14 @@
 # Profile
 
-## Components Intro
+## Components
 
-There are 2 components available:
+### `MimiProfileFragment`
 
-`MimiProfileFragment`: The Mimi Profile Fragment is an expanded view that already contains all the necessary logic for users to personalize their sound, whether they prefer to do so in an easy and quick way, or in a more accurate way by taking a full Hearing Test. In addition, login and signup options are also provided via cards inside the Profile, allowing users to load their previously created Mimi data or save and persist their current data with a Mimi account.
+The Mimi Profile Fragment (`io.mimi.sdk.profile.MimiProfileFragment`) is the MSDK UI entry-point which provides features for users to onboard and personalize their sound. In addition, login and signup options are also provided, allowing users to load their previously created Mimi data or save their current data with a Mimi account.
 
 ![](img/integration/img_1.png)
 
-`MimiProfileLauncher`: The Mimi Launcher Card Fragment is a compact view designed to give one-tap access to the Mimi Profile. It allows you to provide a seamless Mimi Profile experience within your app, while taking a minimal amount of space.
-> Note: This fragment switches to a slider card once some information is provided that can be used to generate some valid presets. This can be done via taking a hearing test, (Profile) or providing a valid YoB (Demographically)
-
-![](img/integration/img_2.png)
-
-You can use these in two ways:
-
-## Add using Kotlin
-
-If you will be adding the Fragment into a `FragmentContainer` or `FrameLayout` dynamically, then make sure you are using the correct Fragment class from the correct package. You can check the import statement for this:
-
-```kotlin
-import io.mimi.sdk.profile.MimiProfileFragment
-import io.mimi.sdk.profile.MimiProfileLauncher
-```
-
-## Add using XML in layout
-
-When using  `FragmentContainer` or `fragment`,
-
-`MimiProfileFragment`:
+The simplest way to add `MimiProfileFragment` is via including in an XML layout.
 
 ```xml
 <androidx.fragment.app.FragmentContainerView
@@ -39,26 +19,11 @@ When using  `FragmentContainer` or `fragment`,
         android:layout_gravity="center" />
 ```
 
-`MimiProfileLauncher`:
+You can also dynamically add a `MimiProfileFragment` instance to your layouts through the standard Android `FragmentManager` mechanism.
 
-```xml
-<androidx.fragment.app.FragmentContainerView
-        android:id="@+id/mimiProfileLauncher"
-        android:name="io.mimi.sdk.profile.MimiProfileLauncher"
-        android:layout_width="320dp"
-        android:layout_height="200dp"
-        android:layout_gravity="center" />
-```
+## Theming
 
-> Note: Adjust the `layout_width` and `layout_height` as per your requirements. We have provided something that usually works in the above example.
-
----
-
-Once you have integrated the UI components, you need to setup the Mimi theme. This is important because without setting it up, your app will crash with the below error:
-
-```error
-Error inflating class androidx.cardview.widget.CardView
-```
+Once you have integrated the UI components, you need to setup the Mimi theme. This is important because without setting it up, your app will crash when attempting to inflate the Mimi UI components.
 
 Now navigate to `AndroidManifest.xml` and check your `<application>` tag. Usually there is a theme already defined. Let's assume it is called `AppTheme`.
 
@@ -74,6 +39,6 @@ Now navigate to where `AppTheme` is defined (should be in `styles.xml` or `theme
 <style name="AppTheme" parent="Theme.Mimi">
 ```
 
-Now, run the app. Everything should be functional.
+Now, run your app. Everything should be functional.
 
 ## [Read core docs for Theming](https://mimihearingtechnologies.github.io/SDK-Android/latest/theming/)

--- a/standard-integration/app/build.gradle
+++ b/standard-integration/app/build.gradle
@@ -59,6 +59,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.6.1'
     implementation 'com.google.android.material:material:1.9.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation  "androidx.fragment:fragment-ktx:1.7.1"
 
     // Testing deps
     testImplementation 'junit:junit:4.13.2'

--- a/standard-integration/app/src/main/java/io/mimi/example/android/IntroFragment.kt
+++ b/standard-integration/app/src/main/java/io/mimi/example/android/IntroFragment.kt
@@ -1,0 +1,79 @@
+package io.mimi.example.android
+
+import android.os.Bundle
+import androidx.fragment.app.Fragment
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Button
+import androidx.fragment.app.add
+import androidx.fragment.app.commit
+import androidx.lifecycle.lifecycleScope
+import io.mimi.sdk.core.MimiCore
+import io.mimi.sdk.core.model.MimiAuthRoute
+import io.mimi.sdk.core.model.tests.MimiTestAudiogram
+import io.mimi.sdk.core.model.tests.TestAudiogramMetadata
+import io.mimi.sdk.profile.MimiProfileFragment
+import kotlinx.coroutines.launch
+import java.util.Date
+
+class IntroFragment : Fragment() {
+    override fun onCreateView(
+        inflater: LayoutInflater, container: ViewGroup?,
+        savedInstanceState: Bundle?
+    ): View? {
+        return inflater.inflate(R.layout.fragment_intro, container, false)
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        with(view) {
+            findViewById<Button>(R.id.launchButton).setOnClickListener {
+                requireActivity().supportFragmentManager.commit {
+                    setReorderingAllowed(true)
+                    add<MimiProfileFragment>(R.id.mimiContainerFragment)
+                    addToBackStack("main")
+                }
+            }
+
+            findViewById<Button>(R.id.submitAudiogram).setOnClickListener {
+                // Send the custom audiogram to the Mimi SDK
+                submitAudiogram()
+            }
+        }
+    }
+
+    private fun submitAudiogram() = lifecycleScope.launch {
+        // Check if there is a user logged in
+        if (MimiCore.userController.mimiUser.state.value == null) {
+            MimiCore.userController.authenticate(MimiAuthRoute.Anonymously)
+        }
+
+        // Submit the custom audiogram
+        MimiCore.testsController.submitAudiogram(
+            leftEar = MimiTestAudiogram(
+                listOf(
+                    MimiTestAudiogram.DataPoint(frequency = 250, threshold = 17.8),
+                    MimiTestAudiogram.DataPoint(frequency = 500, threshold = 18.8),
+                    MimiTestAudiogram.DataPoint(frequency = 1000, threshold = 22.7),
+                    MimiTestAudiogram.DataPoint(frequency = 2000, threshold = 27.6),
+                    MimiTestAudiogram.DataPoint(frequency = 4000, threshold = 29.4),
+                    MimiTestAudiogram.DataPoint(frequency = 8000, threshold = 16.0)
+                )
+            ),
+            rightEar = MimiTestAudiogram(
+                listOf(
+                    MimiTestAudiogram.DataPoint(frequency = 250, threshold = 13.3),
+                    MimiTestAudiogram.DataPoint(frequency = 500, threshold = 17.3),
+                    MimiTestAudiogram.DataPoint(frequency = 1000, threshold = 21.9),
+                    MimiTestAudiogram.DataPoint(frequency = 2000, threshold = 28.9),
+                    MimiTestAudiogram.DataPoint(frequency = 4000, threshold = 28.8),
+                    MimiTestAudiogram.DataPoint(frequency = 8000, threshold = 17.2)
+                )
+            ),
+            metadata = TestAudiogramMetadata(timestamp = Date(System.currentTimeMillis()))
+        )
+    }
+
+
+}

--- a/standard-integration/app/src/main/java/io/mimi/example/android/MainActivity.kt
+++ b/standard-integration/app/src/main/java/io/mimi/example/android/MainActivity.kt
@@ -13,7 +13,6 @@ import android.os.Build
 import android.os.Bundle
 import android.provider.Settings
 import android.util.Log
-import android.widget.Button
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
@@ -39,12 +38,7 @@ import io.mimi.sdk.core.controller.processing.config.dsl.fineTuning
 import io.mimi.sdk.core.controller.processing.config.dsl.mimiProcessingConfiguration
 import io.mimi.sdk.core.controller.processing.config.dsl.personalization
 import io.mimi.sdk.core.internal.MsdkExperimentalApi
-import io.mimi.sdk.core.model.MimiAuthRoute
-import io.mimi.sdk.core.model.tests.MimiTestAudiogram
-import io.mimi.sdk.core.model.tests.MimiTestAudiogram.DataPoint
-import io.mimi.sdk.core.model.tests.TestAudiogramMetadata
 import kotlinx.coroutines.launch
-import java.util.Date
 import kotlin.time.Duration
 import kotlin.time.DurationUnit
 import kotlin.time.toDuration
@@ -313,42 +307,6 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        findViewById<Button>(R.id.sendCustomAudiogramBtn).setOnClickListener {
-            // Send the custom audiogram to the Mimi SDK
-            sendCustomAudioGram()
-        }
-    }
-
-    private fun sendCustomAudioGram() = lifecycleScope.launch {
-        // Check if there is a user logged in
-        if (MimiCore.userController.mimiUser.state.value == null) {
-            MimiCore.userController.authenticate(MimiAuthRoute.Anonymously)
-        }
-
-        // Submit the custom audiogram
-        MimiCore.testsController.submitAudiogram(
-            leftEar = MimiTestAudiogram(
-                listOf(
-                    DataPoint(frequency = 250, threshold = 17.8),
-                    DataPoint(frequency = 500, threshold = 18.8),
-                    DataPoint(frequency = 1000, threshold = 22.7),
-                    DataPoint(frequency = 2000, threshold = 27.6),
-                    DataPoint(frequency = 4000, threshold = 29.4),
-                    DataPoint(frequency = 8000, threshold = 16.0)
-                )
-            ),
-            rightEar = MimiTestAudiogram(
-                listOf(
-                    DataPoint(frequency = 250, threshold = 13.3),
-                    DataPoint(frequency = 500, threshold = 17.3),
-                    DataPoint(frequency = 1000, threshold = 21.9),
-                    DataPoint(frequency = 2000, threshold = 28.9),
-                    DataPoint(frequency = 4000, threshold = 28.8),
-                    DataPoint(frequency = 8000, threshold = 17.2)
-                )
-            ),
-            metadata = TestAudiogramMetadata(timestamp = Date(System.currentTimeMillis()))
-        )
     }
 
     private fun defineMimiProcessingConfiguration(): MimiProcessingConfiguration {

--- a/standard-integration/app/src/main/res/layout/activity_main.xml
+++ b/standard-integration/app/src/main/res/layout/activity_main.xml
@@ -1,24 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.fragment.app.FragmentContainerView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    android:id="@+id/mimiContainerFragment"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="center"
-    android:orientation="vertical"
-    tools:context=".MainActivity">
-
-    <androidx.fragment.app.FragmentContainerView
-        android:id="@+id/mimiProfileLauncher"
-        android:name="io.mimi.sdk.profile.MimiProfileLauncher"
-        android:layout_width="320dp"
-        android:layout_height="200dp" />
-
-    <Button
-        android:id="@+id/sendCustomAudiogramBtn"
-        android:layout_width="304dp"
-        android:layout_height="wrap_content"
-        style="@style/Widget.Mimi.Button"
-        android:layout_marginTop="8dp"
-        android:text="Send custom audiogram" />
-
-</LinearLayout>
+    android:name="io.mimi.example.android.IntroFragment"
+    tools:context=".MainActivity"/>

--- a/standard-integration/app/src/main/res/layout/fragment_intro.xml
+++ b/standard-integration/app/src/main/res/layout/fragment_intro.xml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    tools:context=".MainActivity">
+
+    <TextView
+        android:id="@+id/welcomeTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:text="Welcome to MSDK Example"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="parent" />
+
+    <Button
+        android:id="@+id/launchButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="Launch Mimi Profile"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/welcomeTextView" />
+
+    <View
+        android:id="@+id/divider"
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="48dp"
+        android:background="@color/black"
+        app:layout_constraintTop_toBottomOf="@id/launchButton" />
+
+    <TextView
+        android:id="@+id/extrasTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="48dp"
+        android:text="Extra Tools"
+        android:textSize="24sp"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toTopOf="@id/divider" />
+
+    <Button
+        android:id="@+id/submitAudiogram"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="24dp"
+        android:text="Submit Audiogram Data"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintTop_toBottomOf="@id/extrasTextView" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/standard-integration/app/src/main/res/values/themes.xml
+++ b/standard-integration/app/src/main/res/values/themes.xml
@@ -1,14 +1,6 @@
 <resources xmlns:tools="http://schemas.android.com/tools">
-    <!-- Base application theme. -->
+    <!-- Base application theme extending Mimi theme -->
     <style name="AppTheme" parent="Theme.Mimi">
-        <!-- Primary brand color. -->
-        <item name="colorPrimary">@color/purple_500</item>
-        <item name="colorPrimaryVariant">@color/purple_700</item>
-        <item name="colorOnPrimary">@color/white</item>
-        <!-- Secondary brand color. -->
-        <item name="colorSecondary">@color/teal_200</item>
-        <item name="colorSecondaryVariant">@color/teal_700</item>
-        <item name="colorOnSecondary">@color/black</item>
         <!-- Status bar color. -->
         <item name="android:statusBarColor" >?mimiPrimaryTintColorNormal</item>
         <!-- Customize your theme here. -->


### PR DESCRIPTION
Removes the `MimiProfileLauncher` which will be deprecated in MSDK 10.3.0, from the standard integration UI and documentation.

We recommend replacing the `MimiProfileLauncher` with your own launcher, perhaps a bit more stylish than our example :-).