### PR TITLE
[TASK] Bump to MSDK 11.0.0

### DIFF
--- a/standard-integration/build.gradle
+++ b/standard-integration/build.gradle
@@ -50,7 +50,7 @@ tasks.register('clean', Delete) {
 ext {
     mimiClientID = getBuildProperty("mimiClientID", "CLIENT_ID")
     mimiClientSecret = getBuildProperty("mimiClientSecret", "CLIENT_SECRET")
-    msdkVer = "10.4.0"
+    msdkVer = "11.0.0"
 }
 
 //region Get ENV vars


### PR DESCRIPTION
Bumps the MSDK dependency to 11.0.0. 

This app requires no migration, other integrations may.

- https://mimihearingtechnologies.github.io/SDK-Android/11.0.0/changelog/
- https://mimihearingtechnologies.github.io/SDK-Android/11.0.0/migration/migration-guide-11/