### PR TITLE
[TASK] Bump to MSDK 11.4.0

### DIFF
--- a/standard-integration/build.gradle
+++ b/standard-integration/build.gradle
@@ -50,7 +50,7 @@ tasks.register('clean', Delete) {
 ext {
     mimiClientID = getBuildProperty("mimiClientID", "CLIENT_ID")
     mimiClientSecret = getBuildProperty("mimiClientSecret", "CLIENT_SECRET")
-    msdkVer = "11.3.0"
+    msdkVer = "11.4.0"
 }
 
 //region Get ENV vars


### PR DESCRIPTION
Upgrades to 11.4.0.

No specific migration is required for this app.